### PR TITLE
Typo in dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ This project is heavily inspired by Google's [compile-testing](https://github.co
 <dependency>
     <groupId>com.karuslabs</groupId>
     <artifactId>utilitary</artifactId>
-    <version>1.1.2/version>
+    <version>1.1.2</version>
 </dependency>
 ```


### PR DESCRIPTION
The closing tag of the utilitary version didn't start with an `<`