### PR TITLE
Fix bug with splitting options

### DIFF
--- a/elementary/src/main/java/com/karuslabs/elementary/junit/JavacExtension.java
+++ b/elementary/src/main/java/com/karuslabs/elementary/junit/JavacExtension.java
@@ -72,7 +72,7 @@ public class JavacExtension implements ParameterResolver {
      */
     void resolve(Compiler compiler, AnnotatedElement annotated) {
         var flags = annotated.getAnnotation(Options.class);
-        compiler.options(flags == null ? EMPTY : flags.value().split(" -"));
+        compiler.options(flags == null ? EMPTY : flags.value().split(" "));
         
         var processors = new ArrayList<Processor>();
         var annotation = annotated.getAnnotation(Processors.class);


### PR DESCRIPTION
When supplying the @Options annotation, the bug used to require you to add an extra dash to every argument, apart from the first one (even arguments that didn't have a dash at all). This will fix that.

Note: this doesn't take into account escaped spaces in paths (or spaces in paths that are in quotes). That is for a future time.