### PR TITLE
Found small bug in test for FileObjects.ofLines

### DIFF
--- a/elementary/src/test/java/com/karuslabs/elementary/file/FileObjectsTest.java
+++ b/elementary/src/test/java/com/karuslabs/elementary/file/FileObjectsTest.java
@@ -60,7 +60,7 @@ class FileObjectsTest {
     
     @Test
     void ofLines_varargs() {
-        assertTrue(javac().compile(ofLines("Dummy", List.of("class Dummy {}"))).success);
+        assertTrue(javac().compile(ofLines("Dummy", new String[] {"class Dummy {}"})).success);
     }
     
     @Test


### PR DESCRIPTION
Test was supposed to check the validity of the varargs overload, but it instead tested the Iterable overload. This is fixed now.

Signed-off-by: CC007 <Coolcat_the_best2@Hotmail.com>