### PR TITLE
Provide a Trees object in Tools and in test method parameters

### DIFF
--- a/elementary/src/main/java/com/karuslabs/elementary/junit/DaemonCompiler.java
+++ b/elementary/src/main/java/com/karuslabs/elementary/junit/DaemonCompiler.java
@@ -27,6 +27,7 @@ import com.karuslabs.elementary.Compiler;
 import com.karuslabs.elementary.*;
 import com.karuslabs.utilitary.Logger;
 import com.karuslabs.utilitary.type.TypeMirrors;
+import com.sun.source.util.Trees;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -160,7 +161,7 @@ class DaemonCompiler extends Thread {
                 return false;
             }
             
-            environment.complete(new Environment(round, env.getElementUtils(), env.getTypeUtils(), env.getMessager(), env.getFiler()));
+            environment.complete(new Environment(round, env.getElementUtils(), env.getTypeUtils(), Trees.instance(env), env.getMessager(), env.getFiler()));
             try {
                 completion.await();
             } catch (InterruptedException e) {
@@ -184,16 +185,18 @@ class DaemonCompiler extends Thread {
         public final RoundEnvironment round;
         public final Elements elements;
         public final Types types;
+        public final Trees trees;
         public final Messager messager;
         public final Filer filer;
         public final Labels labels;
         public final TypeMirrors typeMirrors;
         public final Logger logger;
         
-        Environment(RoundEnvironment round, Elements elements, Types types, Messager messager, Filer filer) {
+        Environment(RoundEnvironment round, Elements elements, Types types, Trees trees, Messager messager, Filer filer) {
             this.round = round;
             this.elements = elements;
             this.types = types;
+            this.trees = trees;
             this.messager = messager;
             this.filer = filer;
             labels = new Labels(round);

--- a/elementary/src/main/java/com/karuslabs/elementary/junit/Tools.java
+++ b/elementary/src/main/java/com/karuslabs/elementary/junit/Tools.java
@@ -30,6 +30,7 @@ import com.karuslabs.utilitary.type.TypeMirrors;
 import javax.annotation.processing.*;
 import javax.lang.model.util.*;
 
+import com.sun.source.util.Trees;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -86,6 +87,15 @@ public class Tools {
      */
     public static Types types() {
         return environment().types;
+    }
+
+    /**
+     * Returns a {@code Trees}.
+     *
+     * @return a {@code Trees}
+     */
+    public static Trees trees() {
+        return environment().trees;
     }
     
     /**

--- a/elementary/src/main/java/com/karuslabs/elementary/junit/ToolsExtension.java
+++ b/elementary/src/main/java/com/karuslabs/elementary/junit/ToolsExtension.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Constructor;
 import javax.annotation.processing.*;
 import javax.lang.model.util.*;
 
+import com.sun.source.util.Trees;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import org.junit.jupiter.api.extension.*;
@@ -114,6 +115,9 @@ public class ToolsExtension extends Daemon implements ParameterResolver {
                 
         } else if (type == Types.class) {
             return environment.types;
+
+        } else if (type == Trees.class) {
+            return environment.trees;
             
         } else if (type == Messager.class) {
             return environment.messager;

--- a/elementary/src/test/java/com/karuslabs/elementary/junit/ToolsExtensionTest.java
+++ b/elementary/src/test/java/com/karuslabs/elementary/junit/ToolsExtensionTest.java
@@ -31,6 +31,7 @@ import java.lang.reflect.*;
 import javax.annotation.processing.*;
 import javax.lang.model.util.*;
 
+import com.sun.source.util.Trees;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 
@@ -97,6 +98,11 @@ class ToolsExtensionTest {
     @Test
     void types(Types types) {
         assertNotNull(types);
+    }
+
+    @Test
+    void types(Trees trees) {
+        assertNotNull(trees);
     }
     
     @Test


### PR DESCRIPTION
This Trees object is often used in traversing the AST and depends on the processingEnvironment. Therefore, to be able to test a class that uses this object, it needs to be made available as tool.