### PR TITLE
Add support for JDK9 modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ Please read [upgrading to Elementary 2](./upgrading-to-elementary-2.md) for more
 - Change `Cases` to `Labels`
 - Change `Tools.cases()` to `ToolsExtension.labels()`
 - Change `Compiler`'s classpath related methods to add to the classpath rather than set the classpath
-- Change `DaemonCompiler.Environment.labels` to `DaemonCompiler.Environment.labels`
-- Change `DaemonCompiler.Environment.labels` to `DaemonCompiler.Environment.labels`
+- Change `DaemonCompiler.Environment.cases` to `DaemonCompiler.Environment.labels`
 - Change` DaemonCompiler.of(Class<?>)` to process the given class's module if the module is named
 - Remove `DaemonCompiler.of(AnnotatedConstruct)`
 - Remove `DaemonCompiler.of(List<JavaFileObject>)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Please read [upgrading to Elementary 2](./upgrading-to-elementary-2.md) for more
 
 - Add `Compiler.module(...)`
 - Change `@Case` to `@Label`
-- Change `Labels` to `Labels`
-- Change `Tools.labels()` to `ToolsExtension.labels()`
+- Change `Cases` to `Labels`
+- Change `Tools.cases()` to `ToolsExtension.labels()`
 - Change `Compiler`'s classpath related methods to add to the classpath rather than set the classpath
 - Change `DaemonCompiler.Environment.labels` to `DaemonCompiler.Environment.labels`
 - Change `DaemonCompiler.Environment.labels` to `DaemonCompiler.Environment.labels`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ This release focuses on providing facilities for creating more precise and detai
 This release contains breaking changes that overhaul how elements are retrieved in tests.
 It also provides first-class parameterized test support and JDK9 modules support.
 
-Please
+Please read [upgrading to Elementary 2](./upgrading-to-elementary-2.md) for more information.
 
+- Add `Compiler.module(...)`
 - Change `@Case` to `@Label`
 - Change `Labels` to `Labels`
 - Change `Tools.labels()` to `ToolsExtension.labels()`
+- Change `Compiler`'s classpath related methods to add to the classpath rather than set the classpath
 - Change `DaemonCompiler.Environment.labels` to `DaemonCompiler.Environment.labels`
+- Change `DaemonCompiler.Environment.labels` to `DaemonCompiler.Environment.labels`
+- Change` DaemonCompiler.of(Class<?>)` to process the given class's module if the module is named
+- Remove `DaemonCompiler.of(AnnotatedConstruct)`
+- Remove `DaemonCompiler.of(List<JavaFileObject>)`
 
 ## Utilitary
 - Add `com.karuslabs.utilitary.snippet`

--- a/elementary/nbactions.xml
+++ b/elementary/nbactions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+        <action>
+            <actionName>CUSTOM-Skip Tests</actionName>
+            <displayName>Skip Tests</displayName>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </action>
+    </actions>

--- a/elementary/src/main/java/com/karuslabs/elementary/Compiler.java
+++ b/elementary/src/main/java/com/karuslabs/elementary/Compiler.java
@@ -184,11 +184,7 @@ public class Compiler {
         
         for (var resolved : layer.configuration().modules()) {
             var location = resolved.reference().location().orElseThrow(() -> new IllegalStateException("Could not find location for module: " + resolved.name()));
-            if (classpath == null) {
-                classpath = new HashSet<>();
-            }
-            
-            classpath.add(new File(location.getPath()));
+            classpath().add(new File(location.getPath()));
         }
 
         return this;
@@ -242,11 +238,7 @@ public class Compiler {
             loader = loader.getParent();
         }
         
-        if (classpath == null) {
-            classpath = new HashSet<>();
-        }
-        
-        classpath.addAll(paths.stream().map(File::new).collect(toSet()));
+        classpath().addAll(paths.stream().map(File::new).collect(toSet()));
         
         return this;
     }
@@ -258,12 +250,18 @@ public class Compiler {
      * @return {@code this}
      */
     public Compiler classpath(Collection<File> files) {
+        
+        classpath().addAll(files);
+        return this;
+    }
+    
+    
+    Set<File> classpath() {
         if (classpath == null) {
             classpath = new HashSet<>();
         }
         
-        classpath.addAll(files);
-        return this;
+        return classpath;
     }
     
 }

--- a/elementary/src/main/java/com/karuslabs/elementary/junit/DaemonCompiler.java
+++ b/elementary/src/main/java/com/karuslabs/elementary/junit/DaemonCompiler.java
@@ -31,7 +31,6 @@ import com.sun.source.util.Trees;
 
 import java.util.*;
 import java.util.concurrent.*;
-import java.lang.reflect.AnnotatedElement;
 import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
@@ -55,36 +54,21 @@ class DaemonCompiler extends Thread {
     /**
      * Creates a {@code DaemonCompiler} that compiles the Java source files provided
      * by {@code @Classpath} and {@code Inline} annotations on the given annotated
-     * element.
-     * 
-     * @param annotated the annotated element
-     * @return a {@code DaemonCompiler}
-     */
-    public static DaemonCompiler of(AnnotatedElement annotated) {
-        return of(scan(annotated));
-    }
-    
-    /**
-     * Creates a {@code DaemonCompiler} that compiles the Java source files provided
-     * by {@code @Classpath} and {@code Inline} annotations on the given annotated
      * class.
+     * 
+     * It also adds the classpath and module of the given class if the module is named
+     * to the compilation environment.
      * 
      * @param annotated the annotated class
      * @return a {@code DaemonCompiler}
      */
     public static DaemonCompiler of(Class<?> annotated) {
-        return of(scan(annotated));
-    }
-    
-    /**
-     * Creates a {@code DaemonCompiler} that compiles the given Java source files.
-     * 
-     * @param files the Java source files
-     * @return a {@code DaemonCompiler}
-     */
-    static DaemonCompiler of(List<JavaFileObject> files) {
-        files.add(DUMMY);
-        return new DaemonCompiler(javac().currentClasspath(), files);
+        var files = scan(annotated);
+        if (files.isEmpty()) {
+            files.add(DUMMY);
+        }
+        
+        return new DaemonCompiler(javac().module(annotated.getModule()).currentClasspath(), files);
     }
     
     

--- a/elementary/src/test/java/com/karuslabs/elementary/CompilerTest.java
+++ b/elementary/src/test/java/com/karuslabs/elementary/CompilerTest.java
@@ -85,6 +85,21 @@ class CompilerTest {
     }
     
     
+    
+    @Test
+    void module() {
+        var compiler = javac().module(Object.class.getModule());
+        System.out.println(compiler.classpath);
+        assertFalse(compiler.classpath.isEmpty());
+    }
+    
+    @Test
+    void module_none() {
+        var compiler = javac().module(getClass().getModule()); // This assumes that we're not going to use modules anytime soon
+        assertNull(compiler.classpath);
+    }
+    
+    
     @Test
     void classpath_classloader() throws MalformedURLException {
         var loader = new URLClassLoader(new URL[] {new URL("file", "", 0, "")}, getClass().getClassLoader());


### PR DESCRIPTION
This PR introduces low-level support for JDK 9 modules. Using this approach, it is possible that we do not need to introduce any additional annotations.